### PR TITLE
Add PHP 8.0 tests for Phan

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -22,11 +22,23 @@ jobs:
           - mw: 'REL1_36'
             php: 7.4
             composer: v2
-            continue-on-error: true
+            continue-on-error: false
 
-          # Latest MediaWiki master
+          # Latest MediaWiki master - PHP 7.3
           - mw: 'master'
             php: 7.3
+            composer: v2
+            continue-on-error: false
+
+          # Latest MediaWiki master - PHP 7.4
+          - mw: 'master'
+            php: 7.4
+            composer: v2
+            continue-on-error: false
+
+          # Latest MediaWiki master - PHP 8.0
+          - mw: 'master'
+            php: 8.0
             composer: v2
             continue-on-error: true
 
@@ -47,7 +59,7 @@ jobs:
           composer update
 
       - name: Check PHP
-        if: ${{ matrix.mw == 'master' }}
+        if: ${{ matrix.mw == 'master' && matrix.php == 8.0 }}
         run: |
           sh phpcbf.sh
           composer fix
@@ -82,7 +94,7 @@ jobs:
 
       # Only patch code when it is a push event
       - name: Push the changes
-        if: github.event_name == 'push' && matrix.mw == 'master'
+        if: github.event_name == 'push' && matrix.mw == 'master' && matrix.php == 8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -73,7 +73,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw-${{ matrix.mw }}-php${{ matrix.php }}-v2
+          key: mw-${{ matrix.mw }}-php${{ matrix.php }}-v3
 
       - name: Cache Composer cache
         uses: actions/cache@v2

--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -94,7 +94,7 @@ jobs:
 
       # Only patch code when it is a push event
       - name: Push the changes
-        if: github.event_name == 'push' && matrix.mw == 'master' && matrix.php == 8.0
+        if: ${{ github.event_name == 'push' && matrix.mw == 'master' && matrix.php == 8.0 }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,5 @@
+The PortableInfobox extension was original created by Fandom (Adam Robak, Diana Falkowska, Jacek Jursza, Mateusz Rybarski, Rafał Leszczyński, Sebastian Marzjan).
+
+The original port of the extension was by Luqgreg (Łukasz K.).
+
+This version of PortableInfobox is a fork created by Universal Omega in order to provide better MediaWiki forward compatibility and support

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,10 @@
 	"type": "parserhook",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.36.0"
+		"MediaWiki": ">= 1.36.0",
+		"platform": {
+			"php": ">= 7.2"
+		}
 	},
 	"config": {
 		"AllInfoboxesSubpagesBlacklist": [ "doc", "draft", "test" ],

--- a/extension.json
+++ b/extension.json
@@ -1,13 +1,13 @@
 {
 	"name": "Portable Infobox",
 	"author": [
-		"Fandom (Adam Robak, Diana Falkowska, Jacek Jursza, Mateusz Rybarski, Rafał Leszczyński, Sebastian Marzjan)",
 		"Universal Omega",
-		"Luqgreg (Łukasz K.)"
+		"Luqgreg (Łukasz K.)",
+		"..."
 	],
-	"url": "https://github.com/Luqgreg/mediawiki-PortableInfobox",
+	"url": "https://github.com/Universal-Omega/PortableInfobox",
 	"descriptionmsg": "portable-infobox-desc",
-	"version": "0.3",
+	"version": "0.5",
 	"type": "parserhook",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {

--- a/extension.json
+++ b/extension.json
@@ -13,7 +13,7 @@
 	"requires": {
 		"MediaWiki": ">= 1.36.0",
 		"platform": {
-			"php": ">= 7.2"
+			"php": ">= 7.3"
 		}
 	},
 	"config": {


### PR DESCRIPTION
Also makes the extension require PHP 7.3 or later.

Will drop PHP 7.3 support December 2021, when it goes totally end-of-life.

No end-of-life PHP versions are supported any longer.

Also:
* creates AUTHORS.txt for licensing compatability
* updates `url` in extension.json
* bumps version