### PR TITLE
Enable PHPCS on all PHP and MW version tests and add more Phan tests

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -72,7 +72,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw-${{ matrix.mw }}-php${{ matrix.php }}-v3
+          key: mw-${{ matrix.mw }}-php${{ matrix.php }}-v4
 
       - name: Cache Composer cache
         uses: actions/cache@v2

--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -28,13 +28,13 @@ jobs:
           - mw: 'master'
             php: 7.3
             composer: v2
-            continue-on-error: false
+            continue-on-error: true
 
           # Latest MediaWiki master - PHP 7.4
           - mw: 'master'
             php: 7.4
             composer: v2
-            continue-on-error: false
+            continue-on-error: true
 
           # Latest MediaWiki master - PHP 8.0
           - mw: 'master'

--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -59,7 +59,6 @@ jobs:
           composer update
 
       - name: Check PHP
-        if: ${{ matrix.mw == 'master' && matrix.php == 8.0 }}
         run: |
           sh phpcbf.sh
           composer fix
@@ -94,7 +93,7 @@ jobs:
 
       # Only patch code when it is a push event
       - name: Push the changes
-        if: ${{ github.event_name == 'push' && matrix.mw == 'master' && matrix.php == 8.0 }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -64,16 +64,6 @@ jobs:
           composer fix
           composer test
 
-      - name: Cache MediaWiki
-        id: cache-mediawiki
-        uses: actions/cache@v2
-        with:
-          path: |
-            mediawiki
-            !mediawiki/extensions/
-            !mediawiki/vendor/
-          key: mw-${{ matrix.mw }}-php${{ matrix.php }}-v4
-
       - name: Cache Composer cache
         uses: actions/cache@v2
         with:
@@ -81,7 +71,6 @@ jobs:
           key: composer-php${{ matrix.php }}
 
       - name: Download MediaWiki
-        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         run: |
           bash .github/workflows/download-mediawiki.sh ${{ matrix.mw }}
           git clone https://github.com/wikimedia/mediawiki-extensions-PageImages.git --depth=1 --branch=${{ matrix.mw }} mediawiki/extensions/PageImages

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -68,15 +68,6 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: intl
           tools: composer:${{ matrix.composer }}
-      - name: Cache MediaWiki
-        id: cache-mediawiki
-        uses: actions/cache@v2
-        with:
-          path: |
-            mediawiki
-            !mediawiki/extensions/
-            !mediawiki/vendor/
-          key: mw-${{ matrix.mw }}-php${{ matrix.php }}-mysql${{ matrix.mysql }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v2
@@ -90,7 +81,6 @@ jobs:
           path: installer
 
       - name: Download MediaWiki
-        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
         run: bash installer/.github/workflows/download-mediawiki.sh ${{ matrix.mw }}
 

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -14,7 +14,10 @@ $cfg['exclude_analysis_directory_list'] = array_merge(
 	]
 );
 
-$cfg['suppress_issue_types'] = [];
+$cfg['suppress_issue_types'] = [
+	'PhanPluginMixedKeyNoKey',
+	'SecurityCheck-LikelyFalsePositive',
+];
 
 $cfg['scalar_implicit_cast'] = true;
 

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -14,9 +14,7 @@ $cfg['exclude_analysis_directory_list'] = array_merge(
 	]
 );
 
-$cfg['suppress_issue_types'] = array_merge(
-	$cfg['suppress_issue_types'], []
-);
+$cfg['suppress_issue_types'] = [];
 
 $cfg['scalar_implicit_cast'] = true;
 

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -2,6 +2,7 @@
 <ruleset>
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki" />
 	<file>.</file>
+	<arg name="bootstrap" value="./vendor/mediawiki/mediawiki-codesniffer/utils/bootstrap-ci.php"/>
 	<arg name="extensions" value="php"/>
 	<arg name="encoding" value="UTF-8"/>
 	<exclude-pattern>*/vendor/*</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
 		],
 		"test": [
 			"parallel-lint . --exclude node_modules --exclude vendor",
-			"phpcs --config-set ignore_warnings_on_exit 1",
-			"phpcs -p -s",
-			"minus-x check ."
+			"minus-x check .",
+			"@phpcs"
 		],
-		"phan": "phan -d . --long-progress-bar"
+		"phan": "phan -d . --long-progress-bar",
+		"phpcs": "phpcs -sp --cache"
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"type": "parserhook",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.37.0",
+		"MediaWiki": ">= 1.36.0",
 		"platform": {
 			"php": ">= 7.3"
 		}

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"type": "parserhook",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.36.0",
+		"MediaWiki": ">= 1.37.0",
 		"platform": {
 			"php": ">= 7.3"
 		}

--- a/includes/PortableInfoboxHooks.php
+++ b/includes/PortableInfoboxHooks.php
@@ -5,7 +5,7 @@ use MediaWiki\MediaWikiServices;
 class PortableInfoboxHooks {
 
 	public static function onWgQueryPages( array &$queryPages = [] ) {
-		$queryPages[] = [ 'AllinfoboxesQueryPage', 'AllInfoboxes' ];
+		$queryPages[] = [ 'AllInfoboxesQueryPage', 'AllInfoboxes' ];
 
 		return true;
 	}
@@ -13,8 +13,8 @@ class PortableInfoboxHooks {
 	public static function onBeforeParserrenderImageGallery(
 		Parser &$parser, ImageGalleryBase &$gallery
 	) {
-		// @phan-suppress-next-line PhanDeprecatedProperty
 		PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance()->setGallery(
+			// @phan-suppress-next-line PhanDeprecatedProperty
 			Parser::MARKER_PREFIX . '-gallery-' . sprintf( '%08X', $parser->mMarkerIndex - 1 ) .
 				Parser::MARKER_SUFFIX,
 			$gallery
@@ -25,7 +25,7 @@ class PortableInfoboxHooks {
 
 	public static function onAllInfoboxesQueryRecached() {
 		$cache = MediaWikiServices::getInstance()->getMainWANObjectCache();
-		$cache->delete( $cache->makeKey( ApiQueryAllinfoboxes::MCACHE_KEY ) );
+		$cache->delete( $cache->makeKey( ApiQueryAllInfoboxes::MCACHE_KEY ) );
 
 		return true;
 	}
@@ -33,7 +33,7 @@ class PortableInfoboxHooks {
 	/**
 	 * Purge memcache before edit
 	 *
-	 * @param Page|WikiPage $article
+	 * @param Page $article
 	 *
 	 * @return bool
 	 */
@@ -51,7 +51,7 @@ class PortableInfoboxHooks {
 	/**
 	 * Purge memcache, this will not rebuild infobox data
 	 *
-	 * @param Page|WikiPage $article
+	 * @param Page $article
 	 *
 	 * @return bool
 	 */

--- a/includes/PortableInfoboxHooks.php
+++ b/includes/PortableInfoboxHooks.php
@@ -14,6 +14,7 @@ class PortableInfoboxHooks {
 		Parser &$parser, ImageGalleryBase &$gallery
 	) {
 		PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance()->setGallery(
+			// @phan-suppress-next-line PhanDeprecatedProperty
 			Parser::MARKER_PREFIX . '-gallery-' . sprintf( '%08X', $parser->mMarkerIndex - 1 ) .
 				Parser::MARKER_SUFFIX,
 			$gallery

--- a/includes/PortableInfoboxHooks.php
+++ b/includes/PortableInfoboxHooks.php
@@ -13,8 +13,8 @@ class PortableInfoboxHooks {
 	public static function onBeforeParserrenderImageGallery(
 		Parser &$parser, ImageGalleryBase &$gallery
 	) {
+		// @phan-suppress-next-line PhanDeprecatedProperty
 		PortableInfobox\Helpers\PortableInfoboxDataBag::getInstance()->setGallery(
-			// @phan-suppress-next-line PhanDeprecatedProperty
 			Parser::MARKER_PREFIX . '-gallery-' . sprintf( '%08X', $parser->mMarkerIndex - 1 ) .
 				Parser::MARKER_SUFFIX,
 			$gallery

--- a/includes/controllers/ApiPortableInfobox.php
+++ b/includes/controllers/ApiPortableInfobox.php
@@ -17,7 +17,6 @@ class ApiPortableInfobox extends ApiBase {
 		}
 
 		$parser = MediaWikiServices::getInstance()->getParser();
-		$parser->firstCallInit();
 		$parser->startExternalParse(
 			Title::newFromText( $title ),
 			ParserOptions::newFromContext( $this->getContext() ),

--- a/includes/controllers/PortableInfoboxParserTagController.php
+++ b/includes/controllers/PortableInfoboxParserTagController.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
 use PortableInfobox\Helpers\InfoboxParamsValidator;
 use PortableInfobox\Helpers\InvalidInfoboxParamsException;
 use PortableInfobox\Parser\Nodes;
@@ -139,7 +140,10 @@ class PortableInfoboxParserTagController {
 		}
 
 		// Convert text to language variant
-		$renderedValue = $parser->getTargetLanguageConverter()->convert( $renderedValue );
+		$renderedValue = MediaWikiServices::getInstance()
+			->getLanguageConverterFactory()
+			->getLanguageConverter( $parser->getTargetLanguage() )
+			->convert( $renderedValue );
 
 		return [ $renderedValue, 'markerType' => 'nowiki' ];
 	}

--- a/includes/controllers/PortableInfoboxParserTagController.php
+++ b/includes/controllers/PortableInfoboxParserTagController.php
@@ -139,7 +139,7 @@ class PortableInfoboxParserTagController {
 		}
 
 		// Convert text to language variant
-		$renderedValue = $parser->getTargetLanguage()->convert( $renderedValue );
+		$renderedValue = $parser->getTargetLanguageConverter()->convert( $renderedValue );
 
 		return [ $renderedValue, 'markerType' => 'nowiki' ];
 	}

--- a/includes/querypage/AllInfoboxesQueryPage.php
+++ b/includes/querypage/AllInfoboxesQueryPage.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 class AllInfoboxesQueryPage extends PageQueryPage {
 
 	private const ALL_INFOBOXES_TYPE = 'AllInfoboxes';
@@ -54,7 +56,9 @@ class AllInfoboxesQueryPage extends PageQueryPage {
 	public function recache( $limit = false, $ignoreErrors = true ) {
 		$res = parent::recache( $limit, $ignoreErrors );
 
-		Hooks::run( 'AllInfoboxesQueryRecached' );
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		$hookContainer->run( 'AllInfoboxesQueryRecached' );
+
 		return $res;
 	}
 

--- a/includes/services/Helpers/FileNamespaceSanitizeHelper.php
+++ b/includes/services/Helpers/FileNamespaceSanitizeHelper.php
@@ -2,6 +2,8 @@
 
 namespace PortableInfobox\Helpers;
 
+use MediaWiki\MediaWikiServices;
+
 // original class & authors:
 // https://github.com/Wikia/app/blob/dev/includes/wikia/helpers/FileNamespaceSanitizeHelper.php
 class FileNamespaceSanitizeHelper {
@@ -31,7 +33,9 @@ class FileNamespaceSanitizeHelper {
 		$langCode = $contLang->getCode();
 		if ( empty( $this->filePrefixRegex[$langCode] ) ) {
 			$fileNamespaces = [
-				\MWNamespace::getCanonicalName( NS_FILE ),
+				MediaWikiServices::getInstance()
+					->getNamespaceInfo()
+					->getCanonicalName( NS_FILE ),
 				$contLang->getNamespaces()[NS_FILE],
 			];
 

--- a/includes/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/includes/services/Helpers/PortableInfoboxImagesHelper.php
@@ -2,6 +2,8 @@
 
 namespace PortableInfobox\Helpers;
 
+use MediaWiki\MediaWikiServices;
+
 class PortableInfoboxImagesHelper {
 	private const MAX_DESKTOP_THUMBNAIL_HEIGHT = 500;
 
@@ -123,7 +125,9 @@ class PortableInfoboxImagesHelper {
 		}
 
 		if ( $file instanceof \Title ) {
-			$file = wfFindFile( $file );
+			$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
+
+			$file = $repoGroup->findFile( $file );
 		}
 
 		if ( $file instanceof \File && $file->exists() ) {

--- a/includes/services/Helpers/PortableInfoboxParsingHelper.php
+++ b/includes/services/Helpers/PortableInfoboxParsingHelper.php
@@ -74,9 +74,11 @@ class PortableInfoboxParsingHelper {
 	 */
 	protected function fetchArticleContent( \Title $title ) {
 		if ( $title->exists() ) {
-			$content = \WikiPage::factory( $title )
+			$content = MediaWikiServices::getInstance()
+				->getWikiPageFactory()
+				->newFromTitle( $title )
 				->getContent()
-				->getNativeData();
+				->getText();
 		}
 
 		return isset( $content ) && $content ? $content : '';

--- a/includes/services/Helpers/PortableInfoboxParsingHelper.php
+++ b/includes/services/Helpers/PortableInfoboxParsingHelper.php
@@ -77,8 +77,9 @@ class PortableInfoboxParsingHelper {
 			$content = MediaWikiServices::getInstance()
 				->getWikiPageFactory()
 				->newFromTitle( $title )
-				->getContent()
-				->getText();
+				->getContent();
+
+			$content = $content->getText();
 		}
 
 		return isset( $content ) && $content ? $content : '';

--- a/includes/services/Helpers/PortableInfoboxParsingHelper.php
+++ b/includes/services/Helpers/PortableInfoboxParsingHelper.php
@@ -77,9 +77,8 @@ class PortableInfoboxParsingHelper {
 			$content = MediaWikiServices::getInstance()
 				->getWikiPageFactory()
 				->newFromTitle( $title )
-				->getContent();
-
-			$content = $content->getText();
+				->getContent()
+				->getNativeData();
 		}
 
 		return isset( $content ) && $content ? $content : '';

--- a/includes/services/Helpers/PortableInfoboxParsingHelper.php
+++ b/includes/services/Helpers/PortableInfoboxParsingHelper.php
@@ -74,6 +74,7 @@ class PortableInfoboxParsingHelper {
 	 */
 	protected function fetchArticleContent( \Title $title ) {
 		if ( $title->exists() ) {
+			// @phan-suppress-next-line PhanDeprecatedFunction
 			$content = MediaWikiServices::getInstance()
 				->getWikiPageFactory()
 				->newFromTitle( $title )

--- a/includes/services/Parser/BlockLevelPass.php
+++ b/includes/services/Parser/BlockLevelPass.php
@@ -331,7 +331,7 @@ class BlockLevelPass {
 					while ( preg_match( '/<(\\/?)blockquote[\s>]/i', $t,
 						$bqMatch, PREG_OFFSET_CAPTURE, $bqOffset )
 					) {
-						$inBlockquote = !$bqMatch[1][0]; // is this a close tag?
+						$inBlockquote = !$bqMatch[1][0];
 						$bqOffset = $bqMatch[0][1] + strlen( $bqMatch[0][0] );
 					}
 					$inBlockElem = !$closeMatch;

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -49,14 +49,19 @@ class MediaWikiParserService implements ExternalParser {
 		}
 		$output = BlockLevelPass::doBlockLevels( $parsed, false );
 		$ready = $this->parser->getStripState()->unstripBoth( $output );
+
+		// @phan-suppress-next-line PhanDeprecatedFunction
 		$this->parser->replaceLinkHolders( $ready );
+
 		if ( isset( $this->tidyDriver ) ) {
 			$ready = $this->tidyDriver->tidy( $ready );
 		}
+
 		$newlinesstripped = preg_replace( '|[\n\r]|Us', '', $ready );
 		$marksstripped = preg_replace( '|{{{.*}}}|Us', '', $newlinesstripped );
 
 		$this->cache[$wikitext] = $marksstripped;
+
 		return $marksstripped;
 	}
 

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -72,7 +72,9 @@ class MediaWikiParserService implements ExternalParser {
 	 * @param \Title $title
 	 */
 	public function addImage( $title ) {
-		$file = wfFindFile( $title );
+		$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
+
+		$file = $repoGroup->findFile( $title );
 		$tmstmp = $file ? $file->getTimestamp() : null;
 		$sha1 = $file ? $file->getSha1() : null;
 		$this->parser->getOutput()->addImage( $title->getDBkey(), $tmstmp, $sha1 );

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -42,13 +42,13 @@ class MediaWikiParserService implements ExternalParser {
 			return $this->cache[$wikitext];
 		}
 
-		$parsed = $this->parser->internalParse( $wikitext, false, $this->frame );
+		$parsed = $this->parser->recursiveTagParse( $wikitext, $this->frame );
 		if ( in_array( substr( $parsed, 0, 1 ), [ '*', '#' ] ) ) {
 			// fix for first item list elements
 			$parsed = "\n" . $parsed;
 		}
 		$output = BlockLevelPass::doBlockLevels( $parsed, false );
-		$ready = $this->parser->mStripState->unstripBoth( $output );
+		$ready = $this->parser->getStripState()->unstripBoth( $output );
 		$this->parser->replaceLinkHolders( $ready );
 		if ( isset( $this->tidyDriver ) ) {
 			$ready = $this->tidyDriver->tidy( $ready );


### PR DESCRIPTION
Fixes numerous deprecated functions for MediaWiki 1.36.0+. Currently ignores some which were unfixable as of now. Changes CI to still pass if MediaWiki master fails, for 1.37 related deprecated functions, which have unavailable fixes for 1.36.

Also stops caching MediaWiki in CI.