### PR TITLE
Pass array to `ParserOutput::addModules()`/`addModuleStyles()`

### DIFF
--- a/includes/controllers/PortableInfoboxParserTagController.php
+++ b/includes/controllers/PortableInfoboxParserTagController.php
@@ -124,8 +124,8 @@ class PortableInfoboxParserTagController {
 		$markup = '<' . self::PARSER_TAG_NAME . '>' . $text . '</' . self::PARSER_TAG_NAME . '>';
 		$parserOutput = $parser->getOutput();
 
-		$parserOutput->addModuleStyles( 'ext.PortableInfobox.styles' );
-		$parserOutput->addModules( 'ext.PortableInfobox.scripts' );
+		$parserOutput->addModuleStyles( [ 'ext.PortableInfobox.styles' ] );
+		$parserOutput->addModules( [ 'ext.PortableInfobox.scripts' ] );
 
 		try {
 			$renderedValue = $this->render( $markup, $parser, $frame, $params );


### PR DESCRIPTION
To fix deprecation notices on MediaWiki 1.38+