### PR TITLE
Add support for MediaWiki 1.38

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -17,6 +17,7 @@ $cfg['exclude_analysis_directory_list'] = array_merge(
 $cfg['suppress_issue_types'] = [
 	'PhanPluginMixedKeyNoKey',
 	'SecurityCheck-LikelyFalsePositive',
+	'UnusedPluginSuppression',
 ];
 
 $cfg['scalar_implicit_cast'] = true;

--- a/includes/controllers/PortableInfoboxParserTagController.php
+++ b/includes/controllers/PortableInfoboxParserTagController.php
@@ -175,18 +175,20 @@ class PortableInfoboxParserTagController {
 
 	private static function parserOutputGetPageProperty( \ParserOutput $parserOutput, string $name ) {
 		if ( method_exists( \ParserOutput::class, 'getPageProperty' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod since 1.38
 			return $parserOutput->getPageProperty( $name );
 		} else {
-			// @phan-suppress-next-line PhanUndeclaredMethod deprecated since 1.38
+			// @phan-suppress-next-line PhanDeprecatedFunction deprecated since 1.38
 			return $parserOutput->getProperty( $name );
 		}
 	}
 
 	private static function parserOutputSetPageProperty( \ParserOutput $parserOutput, string $name, $value ) {
 		if ( method_exists( \ParserOutput::class, 'setPageProperty' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod since 1.38
 			$parserOutput->setPageProperty( $name, $value );
 		} else {
-			// @phan-suppress-next-line PhanUndeclaredMethod deprecated since 1.38
+			// @phan-suppress-next-line PhanDeprecatedFunction deprecated since 1.38
 			$parserOutput->setProperty( $name, $value );
 		}
 	}

--- a/includes/controllers/PortableInfoboxParserTagController.php
+++ b/includes/controllers/PortableInfoboxParserTagController.php
@@ -174,19 +174,21 @@ class PortableInfoboxParserTagController {
 	}
 
 	private static function parserOutputGetPageProperty( \ParserOutput $parserOutput, string $name ) {
-		if ( function_exists( \ParserOutput::class, 'getPageProperty' ) ) {
+		if ( method_exists( \ParserOutput::class, 'getPageProperty' ) ) {
 			return $parserOutput->getPageProperty( $name );
+		} else {
+			// deprecated since 1.38
+			return $parserOutput->getProperty( $name );
 		}
-		// deprecated since 1.38
-		return $parserOutput->getProperty( $name );
 	}
 
 	private static function parserOutputSetPageProperty( \ParserOutput $parserOutput, string $name, $value ) {
-		if ( function_exists( \ParserOutput::class, 'getPageProperty' ) ) {
+		if ( method_exists( \ParserOutput::class, 'setPageProperty' ) ) {
 			$parserOutput->setPageProperty( $name, $value );
+		} else {
+			// deprecated since 1.38
+			$parserOutput->setProperty( $name, $value );
 		}
-		// deprecated since 1.38
-		$parserOutput->setProperty( $name, $value );
 	}
 
 	private function handleError( $message ) {

--- a/includes/controllers/PortableInfoboxParserTagController.php
+++ b/includes/controllers/PortableInfoboxParserTagController.php
@@ -177,7 +177,7 @@ class PortableInfoboxParserTagController {
 		if ( method_exists( \ParserOutput::class, 'getPageProperty' ) ) {
 			return $parserOutput->getPageProperty( $name );
 		} else {
-			// deprecated since 1.38
+			// @phan-suppress-next-line PhanUndeclaredMethod deprecated since 1.38
 			return $parserOutput->getProperty( $name );
 		}
 	}
@@ -186,7 +186,7 @@ class PortableInfoboxParserTagController {
 		if ( method_exists( \ParserOutput::class, 'setPageProperty' ) ) {
 			$parserOutput->setPageProperty( $name, $value );
 		} else {
-			// deprecated since 1.38
+			// @phan-suppress-next-line PhanUndeclaredMethod deprecated since 1.38
 			$parserOutput->setProperty( $name, $value );
 		}
 	}

--- a/includes/controllers/PortableInfoboxParserTagController.php
+++ b/includes/controllers/PortableInfoboxParserTagController.php
@@ -122,8 +122,8 @@ class PortableInfoboxParserTagController {
 		$markup = '<' . self::PARSER_TAG_NAME . '>' . $text . '</' . self::PARSER_TAG_NAME . '>';
 		$parserOutput = $parser->getOutput();
 
-		$parserOutput->addModuleStyles( 'ext.PortableInfobox.styles' );
-		$parserOutput->addModules( 'ext.PortableInfobox.scripts' );
+		$parserOutput->addModuleStyles( [ 'ext.PortableInfobox.styles' ] );
+		$parserOutput->addModules( [ 'ext.PortableInfobox.scripts' ] );
 
 		try {
 			$renderedValue = $this->render( $markup, $parser, $frame, $params );
@@ -154,7 +154,7 @@ class PortableInfoboxParserTagController {
 		// (see: PortableInfoboxDataService.class.php)
 
 		$infoboxes = json_decode(
-			$parserOutput->getProperty( PortableInfoboxDataService::INFOBOXES_PROPERTY_NAME ),
+			self::parserOutputGetPageProperty( $parserOutput, PortableInfoboxDataService::INFOBOXES_PROPERTY_NAME ),
 			true
 		);
 
@@ -166,10 +166,27 @@ class PortableInfoboxParserTagController {
 			'metadata' => $raw->getMetadata()
 		];
 
-		$parserOutput->setProperty(
+		self::parserOutputSetPageProperty(
+			$parserOutput,
 			PortableInfoboxDataService::INFOBOXES_PROPERTY_NAME,
 			json_encode( $infoboxes )
 		);
+	}
+
+	private static function parserOutputGetPageProperty( \ParserOutput $parserOutput, string $name ) {
+		if ( function_exists( \ParserOutput::class, 'getPageProperty' ) ) {
+			return $parserOutput->getPageProperty( $name );
+		}
+		// deprecated since 1.38
+		return $parserOutput->getProperty( $name );
+	}
+
+	private static function parserOutputSetPageProperty( \ParserOutput $parserOutput, string $name, $value ) {
+		if ( function_exists( \ParserOutput::class, 'getPageProperty' ) ) {
+			$parserOutput->setPageProperty( $name, $value );
+		}
+		// deprecated since 1.38
+		$parserOutput->setProperty( $name, $value );
 	}
 
 	private function handleError( $message ) {

--- a/includes/services/Helpers/PortableInfoboxParsingHelper.php
+++ b/includes/services/Helpers/PortableInfoboxParsingHelper.php
@@ -69,8 +69,10 @@ class PortableInfoboxParsingHelper {
 
 	private static function parserOutputGetPageProperty( \ParserOutput $parserOutput, string $name ) {
 		if ( method_exists( \ParserOutput::class, 'getPageProperty' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod since 1.38
 			return $parserOutput->getPageProperty( $name );
 		} else {
+			// @phan-suppress-next-line PhanDeprecatedFunction deprecated since 1.38
 			return $parserOutput->getProperty( $name );
 		}
 	}

--- a/includes/services/Helpers/PortableInfoboxParsingHelper.php
+++ b/includes/services/Helpers/PortableInfoboxParsingHelper.php
@@ -46,7 +46,7 @@ class PortableInfoboxParsingHelper {
 				}
 
 				return json_decode(
-					$parser->getOutput()->getProperty( \PortableInfoboxDataService::INFOBOXES_PROPERTY_NAME ),
+					self::parserOutputGetPageProperty( $parser->getOutput(), \PortableInfoboxDataService::INFOBOXES_PROPERTY_NAME ),
 					true
 				);
 			}
@@ -62,9 +62,17 @@ class PortableInfoboxParsingHelper {
 		$parser->parse( $this->fetchArticleContent( $title ), $title, $parserOptions );
 
 		return json_decode(
-			$parser->getOutput()->getProperty( \PortableInfoboxDataService::INFOBOXES_PROPERTY_NAME ),
+			self::parserOutputGetPageProperty( $parser->getOutput(), \PortableInfoboxDataService::INFOBOXES_PROPERTY_NAME ),
 			true
 		);
+	}
+
+	private static function parserOutputGetPageProperty( \ParserOutput $parserOutput, string $name ) {
+		if ( method_exists( \ParserOutput::class, 'getPageProperty' ) ) {
+			return $parserOutput->getPageProperty( $name );
+		} else {
+			return $parserOutput->getProperty( $name );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes

- Deprecated: Use of ParserOutput::addModuleStyles with non-array argument was deprecated in MediaWiki 1.38.
- PhanDeprecatedFunction Call to deprecated function \ParserOutput::getProperty() defined at ../../includes/parser/ParserOutput.php:1413 (Deprecated because: since 1.38, renamed to ::getPageProperty() and returns `null` if no value was set.)