### PR TITLE
Replace deprecated BeforeParserrenderImageGallery hook

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -115,7 +115,7 @@
 	},
 	"Hooks": {
 		"ParserFirstCallInit": "PortableInfoboxParserTagController::parserTagInit",
-		"BeforeParserrenderImageGallery": "PortableInfoboxHooks::onBeforeParserrenderImageGallery",
+		"AfterParserFetchFileAndTitle": "PortableInfoboxHooks::onAfterParserFetchFileAndTitle",
 		"wgQueryPages": "PortableInfoboxHooks::onWgQueryPages",
 		"AllInfoboxesQueryRecached": "PortableInfoboxHooks::onAllInfoboxesQueryRecached",
 		"ArticlePurge": "PortableInfoboxHooks::onArticlePurge",

--- a/includes/PortableInfoboxHooks.php
+++ b/includes/PortableInfoboxHooks.php
@@ -12,8 +12,8 @@ class PortableInfoboxHooks {
 		return true;
 	}
 
-	public static function onBeforeParserrenderImageGallery(
-		Parser &$parser, ImageGalleryBase &$gallery
+	public static function onAfterParserFetchFileAndTitle(
+		Parser $parser, ImageGalleryBase $gallery, string &$html
 	) {
 		PortableInfoboxDataBag::getInstance()->setGallery(
 			// @phan-suppress-next-line PhanDeprecatedProperty


### PR DESCRIPTION
BeforeParserrenderImageGallery hook is deprecated in 1.35.

AfterParserFetchFileAndTitle hook is introduced in 1.35 and this extension requires >=1.37.