### PR TITLE
Add wgPortableInfoboxResponsiblyOpenCollapsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You can use several variables to modify extension's behaviour:
 - `$wgPortableInfoboxCustomImageWidth` (int) - size of image thumbnails used in infoboxes. (default: 300)
 - `$wgPortableInfoboxUseHeadings` (bool) - use heading tags for infobox titles and group headers, it may cause incompatibilities with other extensions. (default: true)
 - `$wgPortableInfoboxUseTidy` (bool) - use [RemexHtml](https://www.mediawiki.org/wiki/RemexHtml) for validating HTML in infoboxes (default: true)
+- `$wgPortableInfoboxResponsiblyOpenCollapsed` (bool) - open collapsed groups when the screen is narrow. (default: true)
 
 ## Usage
 See: https://community.fandom.com/wiki/Help:Infoboxes
@@ -53,5 +54,5 @@ In the 0.3 version, the `<media/>` tag was introduced in favor of `<image/>`, wh
 - `.pi-image-collection` classes were changed to `.pi-media-collection`.
 - `accent-color-*` attributes allow more color formats.
 - More HTML tags are allowed in captions.
-- Mobile skin doesn't get separate styling.
+- Mobile skin doesn't get separate styling except floating and collapsing group features are disabled by default. Set `$wgPortableInfoboxResponsiblyOpenCollapsed` to `false` if you need collapsing group on mobile.
 - It may be *a little* more buggy :)

--- a/extension.json
+++ b/extension.json
@@ -31,6 +31,9 @@
 		},
 		"PortableInfoboxUseTidy": {
 			"value": true
+		},
+		"PortableInfoboxResponsiblyOpenCollapsed": {
+			"value": true
 		}
 	},
 	"MessagesDirs": {
@@ -49,6 +52,7 @@
 			]
 		},
 		"ext.PortableInfobox.styles": {
+			"class": "PortableInfoboxResourceLoaderModule",
 			"styles": "resources/PortableInfobox.less",
 			"targets": [
 				"desktop",
@@ -105,6 +109,7 @@
 		"PortableInfoboxHooks": "includes/PortableInfoboxHooks.php",
 		"PortableInfoboxDataService": "includes/services/PortableInfoboxDataService.php",
 		"PortableInfoboxRenderService": "includes/services/PortableInfoboxRenderService.php",
+		"PortableInfoboxResourceLoaderModule": "includes/resourceloader/PortableInfoboxResourceLoaderModule.php",
 		"PortableInfoboxErrorRenderService": "includes/services/PortableInfoboxErrorRenderService.php",
 		"PortableInfoboxParserTagController": "includes/controllers/PortableInfoboxParserTagController.php",
 		"ApiPortableInfobox": "includes/controllers/ApiPortableInfobox.php",

--- a/includes/resourceloader/PortableInfoboxResourceLoaderModule.php
+++ b/includes/resourceloader/PortableInfoboxResourceLoaderModule.php
@@ -1,0 +1,10 @@
+<?php
+
+class PortableInfoboxResourceLoaderModule extends ResourceLoaderFileModule {
+	/** @inheritDoc */
+	protected function getLessVars( ResourceLoaderContext $context ) {
+		$lessVars = parent::getLessVars( $context );
+		$lessVars[ 'responsibly-open-collapsed'] = $this->getConfig()->get( 'PortableInfoboxResponsiblyOpenCollapsed' );
+		return $lessVars;
+	}
+}

--- a/includes/resourceloader/PortableInfoboxResourceLoaderModule.php
+++ b/includes/resourceloader/PortableInfoboxResourceLoaderModule.php
@@ -4,7 +4,8 @@ class PortableInfoboxResourceLoaderModule extends ResourceLoaderFileModule {
 	/** @inheritDoc */
 	protected function getLessVars( ResourceLoaderContext $context ) {
 		$lessVars = parent::getLessVars( $context );
-		$lessVars[ 'responsibly-open-collapsed'] = $this->getConfig()->get( 'PortableInfoboxResponsiblyOpenCollapsed' );
+		$lessVars[ 'responsibly-open-collapsed'] =
+			(bool)$this->getConfig()->get( 'PortableInfoboxResponsiblyOpenCollapsed' );
 		return $lessVars;
 	}
 }

--- a/resources/PortableInfobox.less
+++ b/resources/PortableInfobox.less
@@ -355,41 +355,51 @@
 	}
 
 }
-@media screen and ( min-width: 720px ) {
-	.client-js {
-		.pi-collapse .pi-header:first-child {
-			padding-right: 25px;
-			position: relative;
-			&::after {
-				border-color: currentColor;
-				border-style: solid;
-				border-width: 2px 2px 0 0;
-				content: '';
-				display: block;
-				height: 5px;
-				right: 10px;
-				position: absolute;
-				top: 50%;
-				width: 5px;
-				.transform( rotate( -45deg ) );
-				margin-top: -3px;
-			}
+
+.pi-collapse() {
+	.pi-collapse .pi-header:first-child {
+		padding-right: 25px;
+		position: relative;
+		&::after {
+			border-color: currentColor;
+			border-style: solid;
+			border-width: 2px 2px 0 0;
+			content: '';
+			display: block;
+			height: 5px;
+			right: 10px;
+			position: absolute;
+			top: 50%;
+			width: 5px;
+			.transform( rotate( -45deg ) );
+			margin-top: -3px;
 		}
-		.pi-collapse-closed {
-			.pi-header:first-child::after {
-				.transform( rotate( 135deg ) );
-				margin-top: -5px;
-			}
-			> :nth-child( n+2 ) {
+	}
+	.pi-collapse-closed {
+		.pi-header:first-child::after {
+			.transform( rotate( 135deg ) );
+			margin-top: -5px;
+		}
+		> :nth-child( n+2 ) {
+			display: none;
+		}
+		.pi-horizontal-group {
+			thead,
+			tbody {
 				display: none;
 			}
-			.pi-horizontal-group {
-				thead,
-				tbody {
-					display: none;
-				}
-			}
 		}
+	}
+}
+
+.client-js {
+	@media screen and ( min-width: 720px ) {
+		& when ( @responsibly-open-collapsed = 1 ) {
+			.pi-collapse()
+		}
+	}
+	& when not ( @responsibly-open-collapsed = 1 ) {
+		.pi-collapse()
 	}
 }
 


### PR DESCRIPTION
Adds $wgPortableInfoboxResponsiblyOpenCollapsed configuration variable. If it equals `false`, collapsing would happen on even mobile and the toggle button would be shown also.

I don't know why the behavior is disabled on mobile, so honestly, I want to just remove it, but this is for backward compatibility.

I would thank requesting changes or any comments.

Closes #58