### PR TITLE
Vertically center data items

### DIFF
--- a/resources/PortableInfobox.less
+++ b/resources/PortableInfobox.less
@@ -130,6 +130,8 @@
 		line-height: inherit;
 	}
 	.pi-data-value {
+		display: flex;
+		align-items: center;
 		flex-basis: 200px;
 		-webkit-flex-basis: 200px;
 		-moz-flex-basis: 200px;


### PR DESCRIPTION
Currently, the data content is not vertically centered (as of MediaWiki 1.38.4). This CSS change fixes that.
