### PR TITLE
Replace deprecated function "mw.user.getName"

### DIFF
--- a/resources/PortableInfoboxBuilder.js
+++ b/resources/PortableInfoboxBuilder.js
@@ -212,7 +212,7 @@
 		}
 
 		clearInfobox() {
-			OO.ui.confirm( mw.message( 'confirmable-confirm', mw.user.getName() ).text() )
+			OO.ui.confirm( mw.message( 'confirmable-confirm', mw.config.get("wgUserName") ).text() )
 				.done( ( confirmed ) => {
 					if ( confirmed ) {
 						this.deselect();


### PR DESCRIPTION
This is to mitigate a bug that has happened in MW 1.39.1. Clicking the "Clear infobox" button caused a TypeError exception: "mw.user.getName is not a function".