### PR TITLE
Output any image candidate markers generated by PageImages

### DIFF
--- a/includes/services/Parser/ExternalParser.php
+++ b/includes/services/Parser/ExternalParser.php
@@ -7,5 +7,5 @@ interface ExternalParser {
 
 	public function replaceVariables( $text );
 
-	public function addImage( $title );
+	public function addImage( $title ): ?string;
 }

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -83,8 +83,9 @@ class MediaWikiParserService implements ExternalParser {
 	 * Add image to parser output for later usage
 	 *
 	 * @param Title $title
+	 * @return ?string PageImages markers, if any.
 	 */
-	public function addImage( $title ) {
+	public function addImage( $title ): ?string {
 		$services = MediaWikiServices::getInstance();
 
 		$repoGroup = $services->getRepoGroup();
@@ -94,7 +95,8 @@ class MediaWikiParserService implements ExternalParser {
 		$sha1 = $file ? $file->getSha1() : null;
 		$this->parser->getOutput()->addImage( $title->getDBkey(), $tmstmp, $sha1 );
 
-		// Pass PI images to PageImages extension if available (Popups and og:image)
+		// Pass PI images to PageImages extension if available (Popups and og:image). Since 1.38, this produces an HTML
+		// comment that must be present in the rendered HTML for the image to qualify for selection.
 		if ( method_exists(
 			ParserFileProcessingHookHandlers::class, 'onParserModifyImageHTML'
 		) ) {
@@ -113,6 +115,10 @@ class MediaWikiParserService implements ExternalParser {
 			$handler->onParserModifyImageHTML(
 				$this->parser, $file, $params, $html
 			);
+
+			return $html;
 		}
+
+		return null;
 	}
 }

--- a/includes/services/Parser/Nodes/NodeMedia.php
+++ b/includes/services/Parser/Nodes/NodeMedia.php
@@ -150,10 +150,6 @@ class NodeMedia extends Node {
 			return [];
 		}
 
-		if ( $titleObj instanceof Title ) {
-			$this->getExternalParser()->addImage( $titleObj );
-		}
-
 		$mediatype = $fileObj->getMediaType();
 		$image = [
 			'url' => $this->resolveImageUrl( $fileObj ),
@@ -166,6 +162,11 @@ class NodeMedia extends Node {
 			'source' => $this->getPrimarySource(),
 			'item-name' => $this->getItemName()
 		];
+
+		if ( $titleObj instanceof Title ) {
+			// This call may produce extra HTML from, for example, the PageImages integration
+			$image['htmlAfter'] = $this->getExternalParser()->addImage( $titleObj );
+		}
 
 		if ( $image['isImage'] ) {
 			$image = array_merge( $image, $helper->extendImageData(

--- a/includes/services/Parser/SimpleParser.php
+++ b/includes/services/Parser/SimpleParser.php
@@ -11,7 +11,8 @@ class SimpleParser implements ExternalParser {
 		return $text;
 	}
 
-	public function addImage( $title ) {
+	public function addImage( $title ): ?string {
 		// do nothing
+		return null;
 	}
 }

--- a/templates/PortableInfoboxItemMedia.hbs
+++ b/templates/PortableInfoboxItemMedia.hbs
@@ -3,7 +3,7 @@
 		{{#if isImage}}<img src="{{thumbnail}}" srcset="{{thumbnail}} 1x, {{thumbnail2x}} 2x" class="pi-image-thumbnail" alt="{{alt}}" width="{{{width}}}" height="{{{height}}}"/>
 		{{else}}{{#if isVideo}}<video src="{{url}}" class="pi-video-player" controls="true" controlsList="nodownload" preload="metadata">{{alt}}</video>
 		{{else}}{{#if isAudio}}<audio src="{{url}}" class="pi-audio-player" controls="true" controlsList="nodownload">{{alt}}</audio>
-		{{else}}{{alt}}{{/if}}{{/if}}{{/if}}
+		{{else}}{{alt}}{{/if}}{{/if}}{{/if}}{{{htmlAfter}}}
 	</a>
 	{{#if caption}}<figcaption class="pi-item-spacing pi-caption">{{{caption}}}</figcaption>{{/if}}
 </figure>

--- a/templates/PortableInfoboxItemMediaCollection.hbs
+++ b/templates/PortableInfoboxItemMediaCollection.hbs
@@ -9,7 +9,7 @@
 					{{#if isImage}}<img src="{{thumbnail}}" srcset="{{thumbnail}} 1x, {{thumbnail2x}} 2x" class="pi-image-thumbnail" alt="{{alt}}" width="{{{width}}}" height="{{{height}}}"/>
 					{{else}}{{#if isVideo}}<video src="{{url}}" class="pi-video-player" controls="true" controlsList="nodownload" preload="metadata">{{alt}}</video>
 					{{else}}{{#if isAudio}}<audio src="{{url}}" class="pi-audio-player" controls="true" controlsList="nodownload">{{alt}}</audio>
-					{{else}}{{alt}}{{/if}}{{/if}}{{/if}}
+					{{else}}{{alt}}{{/if}}{{/if}}{{/if}}{{{htmlAfter}}}
 				</a>
 			</figure>
 		</div>


### PR DESCRIPTION
wikimedia/mediawiki-extensions-PageImages#768464d changed how lead images are identified within PageImages, and since then an HTML comment in the form of `MW-PAGEIMAGES-CANDIDATE-$ID` is output by`doParserModifyImageHTML`, where the ID is an index in the extension output data's list of image metadata. These comments should find a way into the ParserOutput as the extension looks for those comments in a chosen document fragment when identifying qualifying candidates out of all images gathered through `onParserModifyImageHTML`.

This change does not affect compatibility with older PageImages (only the "new" hook's being called already).