### PR TITLE
Add `wgPortableInfoboxUseFileDescriptionPage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can use several variables to modify extension's behaviour:
 - `$wgPortableInfoboxUseHeadings` (bool) - use heading tags for infobox titles and group headers, it may cause incompatibilities with other extensions. (default: true)
 - `$wgPortableInfoboxUseTidy` (bool) - use [RemexHtml](https://www.mediawiki.org/wiki/RemexHtml) for validating HTML in infoboxes (default: true)
 - `$wgPortableInfoboxResponsiblyOpenCollapsed` (bool) - open collapsed groups when the screen is narrow. (default: true)
+- `$wgPortableInfoboxUseFileDescriptionPage` (bool) - control whether or not embedded images in the infobox will link to their file description page instead of directly to the file. (default: false)
 
 ## Usage
 See: https://community.fandom.com/wiki/Help:Infoboxes

--- a/extension.json
+++ b/extension.json
@@ -34,6 +34,9 @@
 		},
 		"PortableInfoboxResponsiblyOpenCollapsed": {
 			"value": true
+		},
+		"PortableInfoboxUseFileDescriptionPage": {
+			"value": false
 		}
 	},
 	"MessagesDirs": {

--- a/includes/services/Parser/Nodes/NodeMedia.php
+++ b/includes/services/Parser/Nodes/NodeMedia.php
@@ -152,7 +152,7 @@ class NodeMedia extends Node {
 
 		$mediatype = $fileObj->getMediaType();
 		$image = [
-			'url' => $this->resolveImageUrl( $fileObj ),
+			'url' => $this->resolveImageUrl( $fileObj, $titleObj ),
 			'name' => $titleObj ? $titleObj->getText() : '',
 			'alt' => $alt ?? ( $titleObj ? $titleObj->getText() : null ),
 			'caption' => $caption ?: null,
@@ -225,9 +225,16 @@ class NodeMedia extends Node {
 	/**
 	 * Returns image url for given image title
 	 * @param File|null $file
+	 * @param Title|null $title
 	 * @return string url or '' if image doesn't exist
 	 */
-	public function resolveImageUrl( $file ) {
+	public function resolveImageUrl( $file, $title ) {
+		global $wgPortableInfoboxUseFileDescriptionPage;
+
+		if ( $wgPortableInfoboxUseFileDescriptionPage && $title ) {
+			return $title->getLocalURL();
+		}
+
 		return $file ? $file->getUrl() : '';
 	}
 


### PR DESCRIPTION
A friend and I are hoping to use this extension in [a wiki](https://rainverse.wiki) we help maintain, but we want image anchor `href`s to link not to the file source, but to the File: namespaced page instead. She wrote the patch, but GitHub prevented her creating an account so I'm helping with the PR (hence the log: "**BlankEclair** authored and **AverageHelper** committed"). I have no means of testing this code myself.

This PR should add a config option to change where the links go, keeping the previous behavior by default.

Fixes #111