### PR TITLE
Add searchaux class to infobox output

### DIFF
--- a/templates/PortableInfoboxWrapper.hbs
+++ b/templates/PortableInfoboxWrapper.hbs
@@ -1,1 +1,1 @@
-<aside class="portable-infobox noexcerpt pi-background{{#if theme}} {{theme}}{{/if}}{{#if layout}} {{layout}}{{/if}}{{#if type}} {{type}}{{/if}}"{{#if item-name}} data-item-name="{{item-name}}"{{/if}}>{{{content}}}</aside>
+<aside class="portable-infobox noexcerpt searchaux pi-background{{#if theme}} {{theme}}{{/if}}{{#if layout}} {{layout}}{{/if}}{{#if type}} {{type}}{{/if}}"{{#if item-name}} data-item-name="{{item-name}}"{{/if}}>{{{content}}}</aside>


### PR DESCRIPTION
In CirrusSearch, [content can be wrapped in class="searchaux" to deprioritize it from search results.](https://www.mediawiki.org/wiki/Help:CirrusSearch#Exclude_content_from_the_search_index) There isn't much use I can think of for infoboxes to be directly displayed in search results.

Additionally, commit f558c16 adds the noexcerpt class to the infobox, [hiding the infobox from Extension:TextExtracts](https://www.mediawiki.org/wiki/Extension:TextExtracts#Configuration_settings), an extension that extracts texts from pages.