### PR TITLE
Prevent DivisionByZeroError in getThumbnailSizes

### DIFF
--- a/includes/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/includes/services/Helpers/PortableInfoboxImagesHelper.php
@@ -110,13 +110,15 @@ class PortableInfoboxImagesHelper {
 		// Handle case where only the original width is zero
 		if ( $originalWidth == 0 ) {
 			$height = min( $maxHeight, $originalHeight );
-			return [ 'height' => round( $height ), 'width' => 0 ]; // No width can be calculated
+			// No width can be calculated
+			return [ 'height' => round( $height ), 'width' => 0 ];
 		}
 
 		// Handle case where only the original height is zero
 		if ( $originalHeight == 0 ) {
 			$width = min( $preferredWidth, $originalWidth );
-			return [ 'height' => 0, 'width' => round( $width ) ]; // No height can be calculated
+			// No height can be calculated
+			return [ 'height' => 0, 'width' => round( $width ) ];
 		}
 
 		// Prevent issues with invalid maxHeight or preferredWidth

--- a/includes/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/includes/services/Helpers/PortableInfoboxImagesHelper.php
@@ -101,6 +101,31 @@ class PortableInfoboxImagesHelper {
 	 * @return array [ 'width' => int, 'height' => int ]
 	 */
 	public function getThumbnailSizes( $preferredWidth, $maxHeight, $originalWidth, $originalHeight ) {
+		// Prevent division by zero by ensuring width and height are valid
+		if ( $originalWidth == 0 && $originalHeight == 0 ) {
+			// Return default sizes if both original dimensions are zero
+			return [ 'height' => 0, 'width' => 0 ];
+		}
+	
+		// Handle case where only the original width is zero
+		if ( $originalWidth == 0 ) {
+			$height = min( $maxHeight, $originalHeight );
+			return [ 'height' => round( $height ), 'width' => 0 ]; // No width can be calculated
+		}
+
+		// Handle case where only the original height is zero
+		if ( $originalHeight == 0 ) {
+			$width = min( $preferredWidth, $originalWidth );
+			return [ 'height' => 0, 'width' => round( $width ) ]; // No height can be calculated
+		}
+	
+		// Prevent issues with invalid maxHeight or preferredWidth
+		if ( $preferredWidth == 0 || $maxHeight == 0 ) {
+			// If either maxHeight or preferredWidth is zero, return the original dimensions
+			return [ 'height' => $originalHeight, 'width' => $originalWidth ];
+		}
+
+		// Standard aspect ratio handling if all dimensions are valid
 		if ( ( $originalHeight / $originalWidth ) > ( $maxHeight / $preferredWidth ) ) {
 			$height = min( $maxHeight, $originalHeight );
 			$width = min( $preferredWidth, $height * $originalWidth / $originalHeight );

--- a/includes/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/includes/services/Helpers/PortableInfoboxImagesHelper.php
@@ -106,7 +106,7 @@ class PortableInfoboxImagesHelper {
 			// Return default sizes if both original dimensions are zero
 			return [ 'height' => 0, 'width' => 0 ];
 		}
-	
+
 		// Handle case where only the original width is zero
 		if ( $originalWidth == 0 ) {
 			$height = min( $maxHeight, $originalHeight );
@@ -118,7 +118,7 @@ class PortableInfoboxImagesHelper {
 			$width = min( $preferredWidth, $originalWidth );
 			return [ 'height' => 0, 'width' => round( $width ) ]; // No height can be calculated
 		}
-	
+
 		// Prevent issues with invalid maxHeight or preferredWidth
 		if ( $preferredWidth == 0 || $maxHeight == 0 ) {
 			// If either maxHeight or preferredWidth is zero, return the original dimensions


### PR DESCRIPTION
https://issue-tracker.miraheze.org/T12591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of edge cases for image thumbnail sizes, preventing errors from zero dimensions.
	- Ensured predictable behavior for invalid input values related to image dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->