### PR TITLE
Fix dark mode styles under skins that use Extension:DarkMode

### DIFF
--- a/resources/PortableInfobox.less
+++ b/resources/PortableInfobox.less
@@ -79,13 +79,13 @@
 	--pi-margin: @pi-margin;
 	--pi-width: @pi-width;
 }
-:root.skin-theme-clientpref-night {
+:root.skin-theme-clientpref-night:not(.client-darkmode) {
 	--pi-background: @pi-background-night;
 	--pi-secondary-background: @pi-secondary-background-night;
 	--pi-border-color-night: @pi-border-color-night;
 }
 @media (prefers-color-scheme: dark) {
-	:root.skin-theme-clientpref-os {
+	:root.skin-theme-clientpref-os:not(.client-darkmode) {
 		--pi-background: @pi-background-night;
 		--pi-secondary-background: @pi-secondary-background-night;
 		--pi-border-color-night: @pi-border-color-night;


### PR DESCRIPTION
Fix #157. I tested with inspector on https://sw3e.miraheze.org/wiki/BlasTech_DL-18_Blaster_Pistol by changing `:root.skin-theme-clientpref-night` to `:root.skin-theme-clientpref-night:not(.client-darkmode)` but didn't test locally.

This fix is only available to logged-in users due to [an Extension:DarkMode bug](https://phabricator.wikimedia.org/T396102).