### PR TITLE
feat: display PortableInfoboxes in VisualEditor

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -34,6 +34,9 @@
 		},
 		"PortableInfoboxUseFileDescriptionPage": {
 			"value": false
+		},
+		"PortableInfoboxVisualEditor": {
+			"value": true
 		}
 	},
 	"MessagesDirs": {
@@ -91,6 +94,17 @@
 				"infoboxbuilder-nodeparam-value",
 				"infoboxbuilder-templatename"
 			]
+		},
+		"ext.PortableInfobox.visualEditor": {
+			"scripts": [
+				"resources/ve.dm.MWPortableInfoboxTransclusion.js",
+				"resources/ve.ce.MWPortableInfoboxTransclusion.js"
+			],
+			"dependencies": [
+				"ext.visualEditor.mwcore",
+				"ext.visualEditor.mwtransclusion",
+				"ext.visualEditor.core"
+			]
 		}
 	},
 	"ResourceFileModulePaths": {
@@ -125,5 +139,6 @@
 	"APIListModules": {
 		"allinfoboxes": "PortableInfobox\\Controllers\\ApiQueryAllInfoboxes"
 	},
+	"ExtensionFunctions": [ "PortableInfobox\\Hooks::onInit" ],
 	"manifest_version": 2
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -89,4 +89,17 @@ class Hooks {
 
 		return true;
 	}
+
+	/**
+	 * This is called from an ExtensionFunction to add the required JavaScript modules
+	 * to display PortableInfoboxes in VisualEditor. The value of $wgPortableInfoboxVisualEditor
+	 * is true by default, therefore requires explicitly disabling if you do not want this behaviour
+	 */
+	public static function onInit() {
+		global $wgPortableInfoboxVisualEditor, $wgVisualEditorPluginModules;
+
+		if ( $wgPortableInfoboxVisualEditor ) {
+			$wgVisualEditorPluginModules[] = 'ext.PortableInfobox.visualEditor';
+		}
+	}
 }

--- a/resources/ve.ce.MWPortableInfoboxTransclusion.js
+++ b/resources/ve.ce.MWPortableInfoboxTransclusion.js
@@ -1,0 +1,59 @@
+/**
+ * This is a really hacky way to display PortableInfoboxes in the VisualEditor. 
+ * It works by retrieving the wikitext from the Parsoid data-mw argument and calling
+ * out to the legacy parser to get back the HTML which should be displayed in the editor. 
+ * 
+ * Note: this is a tempoary workaround to get this working until Parsoid is patched to 
+ * support extensions like this
+ */
+ve.ce.MWPortableInfoboxTransclusion = function VeCeMWPortableInfoboxTransclusion() {
+    ve.ce.MWPortableInfoboxTransclusion.super.apply( this, arguments );
+}
+
+OO.inheritClass( ve.ce.MWPortableInfoboxTransclusion, ve.ce.MWTransclusionBlockNode );
+
+ve.ce.MWPortableInfoboxTransclusion.static.primaryCommandName = 'mwVEPI';
+
+ve.ce.MWPortableInfoboxTransclusion.prototype.onSetup = function () {
+    const modelNode = this.getModel();
+
+    const mwData = modelNode.getAttribute('mw');
+
+    if (mwData && mwData.parts) {
+        // Extract the wikitext from the model -- must be a better way to do this, surely?
+        const params = [];
+        mwData.parts.forEach(part => {
+            if (part.template) {
+                Object.entries(part.template.params).forEach(([key, value]) => {
+                    params.push(`|${key}=${value.wt}`);
+                });
+            }
+        });
+
+        const wikitext = `{{${mwData.parts[0].template.target.wt}${params.join('')}}}`;
+
+        /**
+         * Send this wikitext to the MW API and pray we get HTML back
+         */
+        new mw.Api().post({
+            action: 'parse',
+            text: wikitext,
+            contentmodel: 'wikitext',
+            format: 'json'
+        }).then((response) => {
+            if (response.parse && response.parse.text) {
+                // replace the stub with the HTML, somehow its floated to the left, but I'm not sure why?!
+                const html = response.parse.text['*'];
+                this.$element.empty().append(html);
+            }
+        }).catch((error) => {
+            console.error('Failed to parse infobox:', error);
+        });
+    }
+
+    // Parent method
+    ve.ce.MWPortableInfoboxTransclusion.super.prototype.onSetup.call( this );
+};
+
+
+ve.ce.nodeFactory.register( ve.ce.MWPortableInfoboxTransclusion );

--- a/resources/ve.dm.MWPortableInfoboxTransclusion.js
+++ b/resources/ve.dm.MWPortableInfoboxTransclusion.js
@@ -1,0 +1,26 @@
+/**
+ * see ve.cd.MWPortableInfoboxTransclusion.js for the reasoning for this script
+ */
+ve.dm.MWPortableInfoboxTransclusion = function MWPortableInfoboxTransclusion() {
+    ve.dm.MWPortableInfoboxTransclusion.super.apply( this, arguments );
+}
+
+OO.inheritClass( ve.dm.MWPortableInfoboxTransclusion, ve.dm.MWTransclusionBlockNode );
+
+ve.dm.MWPortableInfoboxTransclusion.static.name = "mwPI";
+
+ve.dm.MWPortableInfoboxTransclusion.static.matchTagNames = null;
+
+ve.dm.MWPortableInfoboxTransclusion.static.extensionName = 'infobox';
+
+ve.dm.MWPortableInfoboxTransclusion.static.matchRdfaTypes = [ 'mw:Transclusion' ];
+
+ve.dm.MWPortableInfoboxTransclusion.static.matchFunction = function ( domElement ) {
+    const about = domElement.getAttribute('about');
+
+    const match = ve.init.target.doc.querySelector( "p[about=\"" + about + "\"][class*='portable-infobox'], p[about=\"" + about + "\"][class*='mw-empty-elt']" );
+
+    return !!match;
+}
+
+ve.dm.modelRegistry.register( ve.dm.MWPortableInfoboxTransclusion );


### PR DESCRIPTION
This PR is an interim, hacky solution to display PortableInfoboxes in the VisualEditor. 

This is a hacky way to achieve a decent result. It works by grabbing the data about the infobox generated by Parsoid (within the `data-mw` attribute, and sending that to the API to parse it as a fragment. We then insert that into the VisualEditor surface where the infobox should be. 

It is behind a feature flag `$wgPortableInfoboxVisualEditor` (open to alternate names, but that's the best I can come up with now), incase users do not want this kind of behaviour. 

This will provide an interim, hacky fix for #132 

### Outstanding Issues before merging:

- [ ] Strip the `mw-content-text` wrappers that are returned from the API and the Parser timing information before inserting into the surface since this is not relevant. 
- [ ] Add back the relevant classes ie `.portable-infobox` et al, this will float the infobox to the right or wherever it actually should be 
- [ ] Introduce a basic `ParsoidModule` to get an `<aside>` tag.

### Parsoid Module
Parsoid cannot currently support PortableInfoboxes as we have discovered - it's not clear how Fandom appears to do this, since their version appears to work fine. What we can do, however, is instruct Parsoid to render the infobox as an `<aside>` rather than the current result which is a `<p>`. This will bring us a step closer to the expected result. 
- [ ] if this box is checked, it's been done.