### PR TITLE
Update extension name to PortableInfobox

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,5 +1,6 @@
 {
-	"name": "Portable Infobox",
+	"name": "PortableInfobox",
+	"namemsg": "portable-infobox-name",
 	"author": [
 		"Universal Omega",
 		"Luqgreg (Łukasz K.)",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,6 +5,7 @@
 			"lkucharczyk"
 		]
 	},
+	"portable-infobox-name": "Portable Infobox",
 	"portable-infobox-desc": "Create portable infoboxes which can be rendered using clean semantic HTML markup on any skin / platform using using easy to understand powerful XML-like markup. Also includes a portable infobox builder at [[Special:PortableInfoboxBuilder]].",
 	"portable-infobox-unimplemented-infobox-tag": "Unimplemented infobox tag: <$1>",
 	"portable-infobox-xml-parse-error-info": "There is a problem with parsing the infobox",


### PR DESCRIPTION
The `name` field in extension.json is more of an internal identifier, and proper localization can be done using the `namemsg` property. This commit fixes that by reverting the `name` field to an internal name, and allowing the name displayed under Special:Version to be localized instead.

This is particularly noteworthy because the [extjsonuploader](https://wikitech.wikimedia.org/wiki/Tool:Extjsonuploader) tool stores the extension.json on mediawiki.org under [`Module:ExtensionJson/Portable_Infobox.json`](https://www.mediawiki.org/wiki/Module:ExtensionJson/Portable_Infobox.json) right now, instead of `Module:ExtensionJson/PortableInfobox.json`, making it hard to automate extension infobox metadata on its [documentation page](https://www.mediawiki.org/wiki/Extension:PortableInfobox). After this change, it should be possible to automate away most of the extension infobox parameters.