### PR TITLE
Don't escape HTML in panel labels

### DIFF
--- a/templates/PortableInfoboxPanel.hbs
+++ b/templates/PortableInfoboxPanel.hbs
@@ -5,7 +5,7 @@
 			<ul class="pi-section-navigation">
 				{{#each sections}}
 					<li class="pi-section-tab pi-item-spacing{{#if active}} pi-section-active{{/if}}" data-ref="{{index}}"{{#if item-name}} data-item-name="{{item-name}}"{{/if}}>
-						<div class="pi-section-label">{{#if label}}{{label}}{{else}}{{index}}{{/if}}</div>
+						<div class="pi-section-label">{{#if label}}{{{label}}}{{else}}{{index}}{{/if}}</div>
 					</li>
 				{{/each}}
 			</ul>


### PR DESCRIPTION
I found that panel tab labels are HTML-escaped because double braces are used instead of triple braces.

An example of this occurs on the [HAPPY HAPPY](https://twice.wiki.gg/wiki/HAPPY_HAPPY?oldid=112941) article from TWICEpedia on wiki.gg, where the tabs under "Song chronology" that have `&` are escaped to show `&amp;`. Another example is on the [STRATEGY](https://twice.wiki.gg/wiki/Strategy?oldid=110788) article, where `#` generates a list, which is rendered as `<ol><li>...</li></ol>` (solved with `<nowiki />`, but ideally the HTML should not be escaped).

#115 seems to be related to this.